### PR TITLE
Updated target platform to 10.10

### DIFF
--- a/Spotify Bluetooth Headset Listener.xcodeproj/project.pbxproj
+++ b/Spotify Bluetooth Headset Listener.xcodeproj/project.pbxproj
@@ -398,7 +398,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Spotify Bluetooth Headset Listener/Spotify Bluetooth Headset Listener-Prefix.pch";
 				INFOPLIST_FILE = "Spotify Bluetooth Headset Listener/Spotify Bluetooth Headset Listener-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -412,7 +412,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Spotify Bluetooth Headset Listener/Spotify Bluetooth Headset Listener-Prefix.pch";
 				INFOPLIST_FILE = "Spotify Bluetooth Headset Listener/Spotify Bluetooth Headset Listener-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};


### PR DESCRIPTION
It was erroring on some missing functionality from 10.8. 

I don't really know the first thing about programming objective-c on osx, but I got it working with this fix. I also worked out the new button code for playpause, but it looks like you've already found that :)